### PR TITLE
self explanatory fibonacci example program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [dependencies]
 openvm = { git = "https://github.com/openvm-org/openvm.git" }
 
+[profile.profiling]
+inherits = "release"
+debug = true
+
 [features]
 default = []
 std = ["openvm/std"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # An example program using OpenVM
 
+## Pre-requisite
+
+- Install OpenVm following as explain in the [book](https://book.openvm.dev/writing-apps/write-program.html)
+
+## Usage
+
+To proof execution to calculate the nth Fibonacci, you just have to follow following commands:
+
+<!-- FIXME:  --> What is the correct format to input a number??
+
+```console
+cargo openvm build
+cargo openvm run --input ???
+cargo openvm keygen
+cargo openvm prove app
+```
+
+## References
+
 See the [book](https://book.openvm.dev/writing-apps/write-program.html) for more details.
+

--- a/openvm.toml
+++ b/openvm.toml
@@ -1,0 +1,3 @@
+[app_vm_config.rv32i]
+[app_vm_config.rv32m]
+[app_vm_config.io]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_main)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use openvm::io::{read, reveal};
+use openvm::io::reveal;
 
 openvm::entry!(main);
 
 pub fn main() {
-    let n: u64 = read();
+    let n: u64 = 100;
     let mut a: u64 = 0;
     let mut b: u64 = 1;
     for _ in 0..n {


### PR DESCRIPTION
Hello!

I was checking [#1156](https://github.com/openvm-org/openvm/issues/1156), and testing how will impact the cli and used this repo. While using it, I realized there are some gaps in repo. In my mind a user coming here should be run the example program with no issues.

For that I: 
1. Provided a default `openvm.toml` data, so user can build out-of-the-box.
2. Extended README.md, so users can test locally if the basic cargo openvm build / run (:construction:) / keygen / prove work.

**:warning: Regarding `cargo openvm run --input ... `**, I intend not to change the code in `src/main.rs` but I having trouble finding any working example to provide a value for n in stdin. I have grep OpenVm source but no luck so far. so I changed it provisionally to get it run. I will undo that change as soon I figure out how to "properly" format the hexstring.